### PR TITLE
fir move node bugs and add CRS verification when load files

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -251,10 +251,11 @@ export default {
         // get selected node
         const features = this.map.querySourceFeatures(this.hoveredStateId.layerId);
         this.selectedFeature = features.filter(item => item.id == this.hoveredStateId.id )[0]
+        let nodeId = this.selectedFeature.properties.index
         // store default position in history
-        let geom =this.editorNodes.features.filter(node=>node.properties.index == this.selectedFeature.properties.index)[0].geometry.coordinates
+        let geom =this.editorNodes.features.filter(node=>node.properties.index == nodeId)[0].geometry.coordinates
         this.$store.commit('addToHistory',{moveNode:{selectedFeature:this.selectedFeature,lngLat:geom}})
-
+        
         // get position
         this.map.on('mousemove',this.onMove)
       }
@@ -271,9 +272,14 @@ export default {
       // stop tracking position (moving node.)
       this.map.getCanvas().style.cursor = 'pointer';
       this.map.off('mousemove', this.onMove);
-      if (this.selectedAction == 'Move Stop') {this.selectClick({mapboxEvent:event})}
-      
-      
+      // emit a clickNode with the selected node.
+      // this will work with lag as it is the selectedFeature and not the highlighted one.
+      if (this.selectedAction == 'Move Stop') {
+        let click = {selectedFeature: this.selectedFeature,
+                     action: this.selectedAction,
+                     lngLat: event.lngLat}
+          this.$emit('clickNode', click);
+       }
     },
 
   },

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -79,13 +79,17 @@ export default {
         fileReader.onload =  evt =>  {
         try{
             this.loadedLinks =  JSON.parse(evt.target.result)
-        } catch (e){ console.log('error') }
+        } catch (e){ 
+          this.$store.commit('changeNotification',{text:e.message, autoClose:true,color:'red darken-2'}); 
+          this.loading[this.choice]=false }
       }
       }else if (this.choice == 'nodes') {
         fileReader.onload =  evt =>  {
         try{
             this.loadedNodes =  JSON.parse(evt.target.result)
-        } catch (e){ console.log('error') }
+        } catch (e){  
+          alert(e.message)
+          this.loading[this.choice]=false }
       }
       }
       


### PR DESCRIPTION
1) when nodes are move. every other links (not editor links) geoemtry is now updated to reflected the new node position.

2) fix move node bug. when it was laggy, the click was not always register (the node was move without the OK dialog).

3) check CRS when a file is loaded.